### PR TITLE
Corrected Time Representation

### DIFF
--- a/Sources/Occurrence/Extensions/Logger+Entry.swift
+++ b/Sources/Occurrence/Extensions/Logger+Entry.swift
@@ -6,7 +6,7 @@ public extension Logger {
         
         public static var gmtDateFormatter: DateFormatter = {
             let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd hh:mm:ss.SSS'Z'"
+            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
             formatter.timeZone = TimeZone(secondsFromGMT: 0)
             return formatter
         }()


### PR DESCRIPTION
The time format was only reported 12-hour time leading to incorrect references.