### PR TITLE
MetadataProvider Support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-          "version": "1.4.2"
+          "revision": "32e8d724467f8fe623624570367e3d50c5638e46",
+          "version": "1.5.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),
+        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.5.2")),
         .package(name: "PerfectSQLite", url: "https://github.com/richardpiazza/Perfect-SQLite", .upToNextMajor(from: "5.1.1")),
         .package(url: "https://github.com/richardpiazza/Statement.git", .upToNextMajor(from: "0.7.1"))
     ],

--- a/Tests/OccurrenceTests/OccurrenceTests.swift
+++ b/Tests/OccurrenceTests/OccurrenceTests.swift
@@ -6,9 +6,13 @@ class OccurrenceTests: XCTestCase {
     
     @LazyLogger(.occurrence) var log: Logger
     
+    let metadataProvider = Logger.MetadataProvider {
+        ["context": "XCTestCase"]
+    }
+    
     override func setUpWithError() throws {
         try super.setUpWithError()
-        Occurrence.bootstrap()
+        Occurrence.bootstrap(metadataProvider: metadataProvider)
     }
     
     override class func tearDown() {
@@ -70,12 +74,12 @@ class OccurrenceTests: XCTestCase {
         description.replaceSubrange(first...last, with: "")
         
         let swiftLog_1_4_2 = """
-        [🔎 INFO     | com.richardpiazza.occurrence | OccurrenceTests OccurrenceTests.swift | testConvenienceObject() 64] Object
-        [object: Item { value: 47 }]
+        [🔎 INFO     | com.richardpiazza.occurrence | OccurrenceTests OccurrenceTests.swift | testConvenienceObject() 68] Object
+        [context: XCTestCase, object: Item { value: 47 }]
         """
         let swiftLog_1_4_3 = """
-        [🔎 INFO     | com.richardpiazza.occurrence | OccurrenceTests.swift | testConvenienceObject() 64] Object
-        [object: Item { value: 47 }]
+        [🔎 INFO     | com.richardpiazza.occurrence | OccurrenceTests.swift | testConvenienceObject() 68] Object
+        [context: XCTestCase, object: Item { value: 47 }]
         """
         
         XCTAssertTrue(description == swiftLog_1_4_2 || description == swiftLog_1_4_3)
@@ -96,12 +100,12 @@ class OccurrenceTests: XCTestCase {
         description.replaceSubrange(first...last, with: "")
         
         let swiftLog_1_4_2 = """
-        [🔎 INFO     | com.richardpiazza.occurrence | OccurrenceTests OccurrenceTests.swift | testConvenienceDictionary() 90] Dictionary
-        [label: count, value: <REDACTED>]
+        [🔎 INFO     | com.richardpiazza.occurrence | OccurrenceTests OccurrenceTests.swift | testConvenienceDictionary() 94] Dictionary
+        [context: XCTestCase, label: count, value: <REDACTED>]
         """
         let swiftLog_1_4_3 = """
-        [🔎 INFO     | com.richardpiazza.occurrence | OccurrenceTests.swift | testConvenienceDictionary() 90] Dictionary
-        [label: count, value: <REDACTED>]
+        [🔎 INFO     | com.richardpiazza.occurrence | OccurrenceTests.swift | testConvenienceDictionary() 94] Dictionary
+        [context: XCTestCase, label: count, value: <REDACTED>]
         """
         
         XCTAssertTrue(description == swiftLog_1_4_2 || description == swiftLog_1_4_3)
@@ -122,12 +126,12 @@ class OccurrenceTests: XCTestCase {
         description.replaceSubrange(first...last, with: "")
         
         let swiftLog_1_4_2 = """
-        [🔎 INFO     | com.richardpiazza.occurrence | OccurrenceTests OccurrenceTests.swift | testConvenienceEncodable() 116] Encodable
-        [id: 123, name: <REDACTED>]
+        [🔎 INFO     | com.richardpiazza.occurrence | OccurrenceTests OccurrenceTests.swift | testConvenienceEncodable() 120] Encodable
+        [context: XCTestCase, id: 123, name: <REDACTED>]
         """
         let swiftLog_1_4_3 = """
-        [🔎 INFO     | com.richardpiazza.occurrence | OccurrenceTests.swift | testConvenienceEncodable() 116] Encodable
-        [id: 123, name: <REDACTED>]
+        [🔎 INFO     | com.richardpiazza.occurrence | OccurrenceTests.swift | testConvenienceEncodable() 120] Encodable
+        [context: XCTestCase, id: 123, name: <REDACTED>]
         """
         
         XCTAssertTrue(description == swiftLog_1_4_2 || description == swiftLog_1_4_3)


### PR DESCRIPTION
* Updated 'swift-log' to 1.5.2
* Support for [`Logger.MetadataProvider`](https://github.com/apple/swift-log/releases/tag/1.5.0)