### PR TITLE
Updated GitHub Action Runners

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,7 +12,7 @@ jobs:
   Swift-Package:
     strategy:
       matrix:
-        os: [macos-12, macos-14, ubuntu-latest]
+        os: [macos-15, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Migrate to **macOS-15** runner image.