### PR TITLE
Standard Output Reflection

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -11,6 +11,7 @@
 --disable blankLinesAtStartOfScope
 --disable hoistPatternLet
 --disable redundantType
+--disable swiftTestingTestCaseNames
 --disable unusedArguments
 --disable wrapArguments
 --disable wrapPropertyBodies

--- a/Sources/Occurrence/Extensions/Logger+Entry.swift
+++ b/Sources/Occurrence/Extensions/Logger+Entry.swift
@@ -67,21 +67,46 @@ public extension Logger {
                 !filters.map { matchesFilter($0) }.contains(true)
             }
         }
+
+        var descriptionPrefix: String {
+            let _date = Self.gmtDateFormatter.string(from: date)
+            let sourceFile = [source, fileName]
+                .filter { !$0.isEmpty }
+                .joined(separator: " ")
+
+            return "[\(_date) \(level.fancyDescription) | \(subsystem) | \(sourceFile) | \(function) \(line)]"
+        }
+    }
+}
+
+extension Logger.Entry: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        let output = "\(descriptionPrefix) \(message)"
+
+        guard let metadata, !metadata.isEmpty else {
+            return output
+        }
+
+        return "\(output)\n\(metadata.prettyDescription)"
     }
 }
 
 extension Logger.Entry: CustomStringConvertible {
     public var description: String {
-        let _date = Self.gmtDateFormatter.string(from: date)
-        let sourceFile = [source, fileName].filter { !$0.isEmpty }.joined(separator: " ")
-        let output = "[\(_date) \(level.fancyDescription) | \(subsystem) | \(sourceFile) | \(function) \(line)] \(message)"
-        if let metadata {
-            let sortedMetadata = metadata.sorted(by: { $0.key < $1.key })
-            let values = sortedMetadata.map { "\($0.key): \($0.value)" }.joined(separator: ", ")
-            return "\(output) { \(values) }"
-        } else {
+        let output = "\(descriptionPrefix) \(message)"
+
+        guard let metadata, !metadata.isEmpty else {
             return output
         }
+
+        let sortedMetadata = metadata
+            .sorted(by: { $0.key < $1.key })
+
+        let values = sortedMetadata
+            .map { "\($0.key): \($0.value)" }
+            .joined(separator: ", ")
+
+        return "\(output) { \(values) }"
     }
 }
 

--- a/Sources/Occurrence/Extensions/Logger.Metadata+Occurrence.swift
+++ b/Sources/Occurrence/Extensions/Logger.Metadata+Occurrence.swift
@@ -18,3 +18,19 @@ public extension Logger.Metadata {
         return NSError(domain: domain, code: code, userInfo: userInfo)
     }
 }
+
+extension Logger.Metadata {
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }()
+
+    var prettyDescription: String {
+        guard let data = try? Self.encoder.encode(self) else {
+            return ""
+        }
+
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/Sources/Occurrence/Occurrence.swift
+++ b/Sources/Occurrence/Occurrence.swift
@@ -4,10 +4,25 @@ import Mutex
 
 public struct Occurrence: LogHandler {
 
+    public enum StandardOutputLevel: Equatable, Sendable {
+        case describing
+        case reflecting
+    }
+
     public struct Configuration: Equatable, Sendable {
-        public var outputToConsole: Bool = true
+        public var standardOutputLevel: StandardOutputLevel? = .describing
         public var outputToStream: Bool = true
         public var outputToStorage: Bool = true
+
+        @available(*, deprecated, renamed: "standardOutputLevel")
+        public var outputToConsole: Bool {
+            get {
+                standardOutputLevel != nil
+            }
+            set {
+                standardOutputLevel = .describing
+            }
+        }
     }
 
     private static let configurationState: Mutex<Configuration> = Mutex(Configuration())
@@ -104,8 +119,13 @@ public struct Occurrence: LogHandler {
             line: line,
         )
 
-        if Self.configuration.outputToConsole {
+        switch Self.configuration.standardOutputLevel {
+        case .describing:
             print(entry)
+        case .reflecting:
+            debugPrint(entry)
+        default:
+            break
         }
 
         if Self.configuration.outputToStream {

--- a/Tests/OccurrenceTests/OccurrenceTests.swift
+++ b/Tests/OccurrenceTests/OccurrenceTests.swift
@@ -75,4 +75,60 @@ final class OccurrenceTests {
 
         #expect(description == output)
     }
+
+    @Test func debugDictionaryConvenience() throws {
+        let dictionary: [String: Any] = [
+            "label": "count",
+            "value": 42,
+        ]
+
+        logger.log(level: .info, "Dictionary", dictionary: dictionary, redacting: ["value"])
+
+        let entry = try #require(Occurrence.logProvider.entries().last)
+        var description = String(reflecting: entry)
+
+        // Remove the timestamp
+        let first = description.index(description.startIndex, offsetBy: 1)
+        let last = description.index(description.startIndex, offsetBy: 25)
+        description.replaceSubrange(first ... last, with: "")
+
+        let output = """
+        [🔎 INFO     | com.richardpiazza.occurrence | OccurrenceTests OccurrenceTests.swift | debugDictionaryConvenience() 85] Dictionary
+        {
+          "context" : "XCTestCase",
+          "label" : "count",
+          "value" : "<REDACTED>"
+        }
+        """
+
+        #expect(description == output)
+    }
+
+    @Test func debugEncodableConvenience() throws {
+        struct Metadata: Encodable {
+            let id: Int
+            let name: String
+        }
+
+        logger.log(level: .info, "Encodable", encodable: Metadata(id: 123, name: "Bob"), redacting: ["name"])
+
+        let entry = try #require(Occurrence.logProvider.entries().last)
+        var description = String(reflecting: entry)
+
+        // Remove the timestamp
+        let first = description.index(description.startIndex, offsetBy: 1)
+        let last = description.index(description.startIndex, offsetBy: 25)
+        description.replaceSubrange(first ... last, with: "")
+
+        let output = """
+        [🔎 INFO     | com.richardpiazza.occurrence | OccurrenceTests OccurrenceTests.swift | debugEncodableConvenience() 113] Encodable
+        {
+          "context" : "XCTestCase",
+          "id" : 123,
+          "name" : "<REDACTED>"
+        }
+        """
+
+        #expect(description == output)
+    }
 }


### PR DESCRIPTION
Adds a new configuration option to set an `Logger.Entry` output level: either `describing` or `reflecting`. Reflecting will present additional metadata captured with the entry.